### PR TITLE
feat(events): Add eventPattern to settings

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -10,7 +10,8 @@ component {
             allowMethods = [ "DELETE", "GET", "PATCH", "POST", "PUT", "OPTIONS" ],
             allowHeaders = [ "Content-Type", "X-Auth-Token", "Origin", "Authorization" ],
             maxAge = 60 * 60 * 24, // 1 day
-            allowCredentials = true
+            allowCredentials = true,
+            eventPattern = ".*"
         };
 
         interceptors = [

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ settings = {
     allowMethods = [ "DELETE", "GET", "PATCH", "POST", "PUT", "OPTIONS" ],
     allowHeaders = [ "Content-Type", "X-Auth-Token", "Origin", "Authorization" ],
     maxAge = 60 * 60 * 24, // 1 day
-    allowCredentials = true
+    allowCredentials = true,
+    eventPattern = [ "^Main\.ajax$", "api" ]
 };
 ```

--- a/tests/resources/app/handlers/Main.cfc
+++ b/tests/resources/app/handlers/Main.cfc
@@ -1,1 +1,54 @@
-﻿component extends="coldbox.system.EventHandler"{	// Default Action	function index(event,rc,prc){		prc.welcomeMessage = "Welcome to ColdBox!";		event.setView("main/index");	}	// Do something	function doSomething(event,rc,prc){		setNextEvent("main.index");	}	/************************************** IMPLICIT ACTIONS *********************************************/	function onAppInit(event,rc,prc){	}	function onRequestStart(event,rc,prc){	}	function onRequestEnd(event,rc,prc){	}	function onSessionStart(event,rc,prc){	}	function onSessionEnd(event,rc,prc){		var sessionScope = event.getValue("sessionReference");		var applicationScope = event.getValue("applicationReference");	}	function onException(event,rc,prc){		//Grab Exception From private request collection, placed by ColdBox Exception Handling		var exception = prc.exception;		//Place exception handler below:	}	function onMissingTemplate(event,rc,prc){		//Grab missingTemplate From request collection, placed by ColdBox		var missingTemplate = event.getValue("missingTemplate");	}}
+﻿component extends="coldbox.system.EventHandler"{
+
+	// Default Action
+	function index(event,rc,prc){
+		prc.welcomeMessage = "Welcome to ColdBox!";
+		event.setView("main/index");
+	}
+
+	// Do something
+	function doSomething(event,rc,prc){
+		setNextEvent("main.index");
+    }
+
+    function doSomethingElse(event,rc,prc){
+        setNextEvent("main.index");
+    }
+
+	/************************************** IMPLICIT ACTIONS *********************************************/
+
+	function onAppInit(event,rc,prc){
+
+	}
+
+	function onRequestStart(event,rc,prc){
+
+	}
+
+	function onRequestEnd(event,rc,prc){
+
+	}
+
+	function onSessionStart(event,rc,prc){
+
+	}
+
+	function onSessionEnd(event,rc,prc){
+		var sessionScope = event.getValue("sessionReference");
+		var applicationScope = event.getValue("applicationReference");
+	}
+
+	function onException(event,rc,prc){
+		//Grab Exception From private request collection, placed by ColdBox Exception Handling
+		var exception = prc.exception;
+		//Place exception handler below:
+
+	}
+
+	function onMissingTemplate(event,rc,prc){
+		//Grab missingTemplate From request collection, placed by ColdBox
+		var missingTemplate = event.getValue("missingTemplate");
+
+	}
+
+}

--- a/tests/specs/integration/CORSSpec.cfc
+++ b/tests/specs/integration/CORSSpec.cfc
@@ -8,6 +8,12 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 getPageContext().getResponse().reset();
             } );
 
+            aroundEach( function( spec ) {
+                var originalSettings = duplicate( getController().getConfigSettings().modules.cors.settings );
+                spec.body();
+                getController().getConfigSettings().modules.cors.settings = originalSettings;
+            } );
+
             it( "activates the module", function() {
                 expect( getController().getModuleService().isModuleRegistered( "cors" ) ).toBeTrue();
             } );
@@ -131,7 +137,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                     .$( "getHTTPMethod", "OPTIONS" )
                     .$( "getHTTPHeader" )
                     .$args( "Origin", "" )
-                    .$results( "example.com" );;
+                    .$results( "example.com" );
                 var event = execute( route = "/", renderResults = true );
 
                 expect( getHeader( "Access-Control-Allow-Headers" ) )
@@ -145,7 +151,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                     .$( "getHTTPMethod", "OPTIONS" )
                     .$( "getHTTPHeader" )
                     .$args( "Origin", "" )
-                    .$results( "example.com" );;
+                    .$results( "example.com" );
                 var event = execute( route = "/", renderResults = true );
 
                 expect( getHeader( "Access-Control-Allow-Credentials" ) )
@@ -159,7 +165,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                     .$( "getHTTPMethod", "OPTIONS" )
                     .$( "getHTTPHeader" )
                     .$args( "Origin", "" )
-                    .$results( "example.com" );;
+                    .$results( "example.com" );
                 var event = execute( route = "/", renderResults = true );
 
                 expect( getHeader( "Access-Control-Max-Age" ) )
@@ -181,6 +187,85 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 expect( getHeader( "Access-Control-Allow-Headers" ) )
                     .toBe( "Content-Type, X-Auth-Token, Origin", "The 'Access-Control-Allow-Headers' should be set to 'Content-Type, X-Auth-Token, Origin'." );
+            } );
+
+            it( "can be configured with a regex for routes to process", function() {
+                getController().getConfigSettings().modules.cors.settings.eventPattern = "Main\.doSomething$";
+
+                prepareMock( getRequestContext() )
+                    .$( "getHTTPMethod", "OPTIONS" )
+                    .$( "getHTTPHeader" )
+                    .$args( "Origin", "" )
+                    .$results( "example.com" );
+                var event = execute( event = "Main.index", renderResults = true );
+
+                expect( getHeaderNames() )
+                    .notToInclude( "Access-Control-Allow-Origin", "The 'Access-Control-Allow-Origin' should not be set." );
+
+                getPageContext().getResponse().reset();
+
+                prepareMock( getRequestContext() )
+                    .$( "getHTTPMethod", "OPTIONS" )
+                    .$( "getHTTPHeader" )
+                    .$args( "Origin", "" )
+                    .$results( "example.com" );
+                var event = execute( event = "Main.doSomething", renderResults = true );
+
+                expect( getHeader( "Access-Control-Allow-Origin" ) )
+                    .toBe( "*", "The 'Access-Control-Allow-Origin' should be set to '*'." );
+
+                getPageContext().getResponse().reset();
+
+                prepareMock( getRequestContext() )
+                    .$( "getHTTPMethod", "OPTIONS" )
+                    .$( "getHTTPHeader" )
+                    .$args( "Origin", "" )
+                    .$results( "example.com" );
+                var event = execute( event = "Main.doSomethingElse", renderResults = true );
+
+                expect( getHeaderNames() )
+                    .notToInclude( "Access-Control-Allow-Origin", "The 'Access-Control-Allow-Origin' should not be set." );
+            } );
+
+            it( "can be configured with a regex for routes to process", function() {
+                getController().getConfigSettings().modules.cors.settings.eventPattern = [
+                    "Main\.doSomething$",
+                    "doSomething"
+                ];
+
+                prepareMock( getRequestContext() )
+                    .$( "getHTTPMethod", "OPTIONS" )
+                    .$( "getHTTPHeader" )
+                    .$args( "Origin", "" )
+                    .$results( "example.com" );
+                var event = execute( event = "Main.index", renderResults = true );
+
+                expect( getHeaderNames() )
+                    .notToInclude( "Access-Control-Allow-Origin", "The 'Access-Control-Allow-Origin' should not be set." );
+
+                getPageContext().getResponse().reset();
+
+                prepareMock( getRequestContext() )
+                    .$( "getHTTPMethod", "OPTIONS" )
+                    .$( "getHTTPHeader" )
+                    .$args( "Origin", "" )
+                    .$results( "example.com" );
+                var event = execute( event = "Main.doSomething", renderResults = true );
+
+                expect( getHeader( "Access-Control-Allow-Origin" ) )
+                    .toBe( "*", "The 'Access-Control-Allow-Origin' should be set to '*'." );
+
+                getPageContext().getResponse().reset();
+
+                prepareMock( getRequestContext() )
+                    .$( "getHTTPMethod", "OPTIONS" )
+                    .$( "getHTTPHeader" )
+                    .$args( "Origin", "" )
+                    .$results( "example.com" );
+                var event = execute( event = "Main.doSomethingElse", renderResults = true );
+
+                expect( getHeader( "Access-Control-Allow-Origin" ) )
+                    .toBe( "*", "The 'Access-Control-Allow-Origin' should be set to '*'." );
             } );
         } );
     }


### PR DESCRIPTION
Event Patterns allow you to restrict the routes that the CORS module will process.
By default, the module processes all routes.  The setting can take either
a single event pattern as a string or an array of event patterns. If any
event pattern matches, the request will be processed through the CORS interceptor.